### PR TITLE
Chapter9

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -182,3 +182,17 @@ input {
     color: $state-danger-text;
   }
 }
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
       log_in user
-      remember user
+      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user&.authenticate(params[:session][:password])
       log_in user
+      remember user
       redirect_to user
     else
       flash.now[:danger] = 'Invalid email/password combination'
@@ -13,7 +14,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     redirect_to root_url
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -7,14 +7,14 @@ module SessionsHelper
     user.remember
     cookies.permanent.signed[:user_id] = user.id
     cookies.permanent[:remember_token] = user.remember_token
-  end      
+  end
 
   def current_user
-    if (user_id = session[:user_id])
-      @current_user ||= User.find_by(id: user_id)
-    elsif (user_id = cookies.signed[:user_id])
-      user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+    if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id])
+    elsif cookies.signed[:user_id]
+      user = User.find_by(id: session[:user_id])
+      if user&.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -3,10 +3,28 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
-  def current_user
-    return unless session[:user_id]
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end      
 
-    @current_user ||= User.find_by(id: session[:user_id])
+  def current_user
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
+  end
+
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
   end
 
   def logged_in?
@@ -14,6 +32,7 @@ module SessionsHelper
   end
 
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :remember_token
   before_save { email.downcase! }
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i.freeze
@@ -14,5 +15,21 @@ class User < ApplicationRecord
              BCrypt::Engine.cost
            end
     BCrypt::Password.create(string, cost: cost)
+  end
+
+  def self.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  def remember 
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
+  end
+  def authenticated?(remember_token)
+    return false if remember_digest.nil?
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
+  def forget
+    update_attribute(:remember_digest, nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
+
   before_save { email.downcase! }
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i.freeze
@@ -21,14 +22,17 @@ class User < ApplicationRecord
     SecureRandom.urlsafe_base64
   end
 
-  def remember 
+  def remember
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
+
   def authenticated?(remember_token)
     return false if remember_digest.nil?
+
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
+
   def forget
     update_attribute(:remember_digest, nil)
   end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>Remember me on this computer</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/db/migrate/20230911061004_add_remember_digest_to_users.rb
+++ b/db/migrate/20230911061004_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_23_050053) do
+ActiveRecord::Schema.define(version: 2023_09_11_061004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2023_08_23_050053) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe User, type: :model do
     expect(user).to_not be_valid
   end
 
+  describe '#authenticated?' do
+    it 'digestがnilならfalseを返すこと' do
+      expect(user.authenticated?('')).to be_falsy
+    end
+  end
+
   # describe 'POST /users #create' do
   #   it '無効な値だと登録されないこと' do
   #     expect {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe User, type: :model do
 
   describe '#authenticated?' do
     it 'digestがnilならfalseを返すこと' do
-      expect(user.authenticated?('')).to be_falsy
+      expect(user.authenticated?('')).to be(false)
     end
   end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -14,16 +14,34 @@ RSpec.describe 'Sessions', type: :request do
                                             password: user.password } }
     end
     it 'ログアウトできること' do
-      expect(logged_in?).to be_truthy
+      expect(logged_in?).to be(true)
 
       delete logout_path
-      expect(logged_in?).to_not be_truthy
+      expect(logged_in?).to_not be(true)
     end
     it '2回連続でログアウトしてもエラーにならないこと' do
       delete logout_path
       delete logout_path
       expect(response).to redirect_to root_path
     end
-   
+  end
+  describe '#create' do
+    let(:user) { FactoryBot.create(:user) }
+
+    describe 'remember me' do
+      it 'ONの場合はcookies[:remember_token]が空でないこと' do
+        post login_path, params: { session: { email: user.email,
+                                              password: user.password,
+                                              remember_me: 1 } }
+        expect(cookies[:remember_token]).to_not be_blank
+      end
+
+      it 'OFFの場合はcookies[:remember_token]が空であること' do
+        post login_path, params: { session: { email: user.email,
+                                              password: user.password,
+                                              remember_me: 0 } }
+        expect(cookies[:remember_token]).to be_blank
+      end
+    end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -8,14 +8,22 @@ RSpec.describe 'Sessions', type: :request do
     end
   end
   describe 'DELETE /logout' do
-    it 'ログアウトできること' do
+    before do
       user = FactoryBot.create(:user)
       post login_path, params: { session: { email: user.email,
                                             password: user.password } }
+    end
+    it 'ログアウトできること' do
       expect(logged_in?).to be_truthy
 
       delete logout_path
       expect(logged_in?).to_not be_truthy
     end
+    it '2回連続でログアウトしてもエラーにならないこと' do
+      delete logout_path
+      delete logout_path
+      expect(response).to redirect_to root_path
+    end
+   
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Users', type: :request do
     end
     it 'ログイン状態であること' do
       post users_path, params: user_params
-      expect(logged_in?).to be_truthy
+      expect(logged_in?).to be(true)
     end
   end
 end


### PR DESCRIPTION
ページの長時間での保持のため永続的なセッションを導入
永続的なセッションをユーザーごとに関連付ける
ログイン・ログアウトでそのセッションを管理する